### PR TITLE
feat(label): improve label text encoding performance

### DIFF
--- a/fastmetrics/src/format/text.rs
+++ b/fastmetrics/src/format/text.rs
@@ -198,45 +198,68 @@ where
         self.writer.write_str(self.metric_name.as_ref())
     }
 
-    fn encode_label_set(&mut self, additional_labels: Option<&dyn EncodeLabelSet>) -> fmt::Result {
+    /// Pre-encode common labels (const_labels + family_labels) to a string buffer
+    fn encode_common_labels_to_string(&self) -> Result<Option<String>, fmt::Error> {
         let has_const_labels = !self.const_labels.is_empty();
         let has_family_labels = match self.family_labels {
             None => false,
             Some(labels) if labels.is_empty() => false,
             Some(_) => true,
         };
+
+        if !has_const_labels && !has_family_labels {
+            return Ok(None);
+        }
+
+        let mut common_labels = String::new();
+
+        if has_const_labels {
+            self.const_labels.encode(&mut LabelSetEncoder::new(
+                &mut common_labels,
+                LabelNameCheck::Enable(self.metric_type),
+            ))?;
+        }
+
+        if let Some(family_labels) = self.family_labels {
+            if has_family_labels {
+                if has_const_labels {
+                    common_labels.push(',');
+                }
+                family_labels.encode(&mut LabelSetEncoder::new(
+                    &mut common_labels,
+                    LabelNameCheck::Enable(self.metric_type),
+                ))?;
+            }
+        }
+
+        Ok(Some(common_labels))
+    }
+
+    /// Encode label set with pre-computed common labels for better performance
+    fn encode_label_set_with_common(
+        &mut self,
+        common_labels: Option<&str>,
+        additional_labels: Option<&dyn EncodeLabelSet>,
+    ) -> fmt::Result {
+        let has_common_labels = common_labels.is_some();
         let has_additional_labels = match additional_labels {
             None => false,
             Some(labels) if labels.is_empty() => false,
             Some(_) => true,
         };
 
-        if !has_const_labels && !has_family_labels && !has_additional_labels {
+        if !has_common_labels && !has_additional_labels {
             self.writer.write_str(" ")?;
             return Ok(());
         }
 
         self.writer.write_str("{")?;
-        if has_const_labels {
-            self.const_labels.encode(&mut LabelSetEncoder::new(
-                self.writer,
-                LabelNameCheck::Enable(self.metric_type),
-            ))?;
-        }
-        if let Some(family_labels) = self.family_labels {
-            if has_family_labels {
-                if has_const_labels {
-                    self.writer.write_str(",")?;
-                }
-                family_labels.encode(&mut LabelSetEncoder::new(
-                    self.writer,
-                    LabelNameCheck::Enable(self.metric_type),
-                ))?;
-            }
+        if let Some(common) = common_labels {
+            self.writer.write_str(common)?;
         }
         if let Some(additional_labels) = additional_labels {
             if has_additional_labels {
-                if has_const_labels || has_family_labels {
+                if has_common_labels {
                     self.writer.write_str(",")?;
                 }
                 additional_labels
@@ -246,12 +269,20 @@ where
         self.writer.write_str("} ")
     }
 
+    fn encode_label_set(&mut self, additional_labels: Option<&dyn EncodeLabelSet>) -> fmt::Result {
+        let common_labels = self.encode_common_labels_to_string()?;
+        self.encode_label_set_with_common(common_labels.as_deref(), additional_labels)
+    }
+
     fn encode_buckets(
         &mut self,
         buckets: &[Bucket],
         exemplars: &[Option<&dyn EncodeExemplar>],
     ) -> fmt::Result {
         assert_eq!(buckets.len(), exemplars.len(), "buckets and exemplars count mismatch");
+
+        // pre-encode common labels once
+        let common_labels = self.encode_common_labels_to_string()?;
 
         let mut cumulative_count = 0;
         for (bucket, exemplar) in buckets.iter().zip(exemplars) {
@@ -260,10 +291,18 @@ where
 
             let upper_bound = bucket.upper_bound();
             let bucket_count = bucket.count();
+
+            // use pre-computed common labels
             if upper_bound == f64::INFINITY {
-                self.encode_label_set(Some(&[(BUCKET_LABEL, "+Inf")]))?;
+                self.encode_label_set_with_common(
+                    common_labels.as_deref(),
+                    Some(&[(BUCKET_LABEL, "+Inf")]),
+                )?;
             } else {
-                self.encode_label_set(Some(&[(BUCKET_LABEL, upper_bound)]))?;
+                self.encode_label_set_with_common(
+                    common_labels.as_deref(),
+                    Some(&[(BUCKET_LABEL, upper_bound)]),
+                )?;
             }
 
             cumulative_count += bucket_count;
@@ -390,10 +429,16 @@ where
     }
 
     fn encode_stateset(&mut self, states: Vec<(&str, bool)>) -> fmt::Result {
+        // pre-encode common labels once
+        let common_labels = self.encode_common_labels_to_string()?;
+
         // encode state metrics
         for (state, enabled) in states {
             self.encode_metric_name()?;
-            self.encode_label_set(Some(&[(self.metric_name.clone(), state)]))?;
+            self.encode_label_set_with_common(
+                common_labels.as_deref(),
+                Some(&[(self.metric_name.clone(), state)]),
+            )?;
             if enabled {
                 self.writer.write_str("1")?;
             } else {
@@ -459,10 +504,16 @@ where
         count: u64,
         created: Option<Duration>,
     ) -> fmt::Result {
+        // pre-encode common labels once
+        let common_labels = self.encode_common_labels_to_string()?;
+
         // encode quantile metrics
         for quantile in quantiles {
             self.encode_metric_name()?;
-            self.encode_label_set(Some(&[(QUANTILE_LABEL, quantile.quantile())]))?;
+            self.encode_label_set_with_common(
+                common_labels.as_deref(),
+                Some(&[(QUANTILE_LABEL, quantile.quantile())]),
+            )?;
             self.writer.write_str(dtoa::Buffer::new().format(quantile.value()))?;
             self.encode_timestamp()?;
             self.encode_newline()?;


### PR DESCRIPTION
This pull request improves the performance and maintainability of label encoding in the Prometheus text format exporter by introducing pre-encoding of common labels and refactoring the label encoding logic. The main idea is to precompute constant and family labels once per metric, and reuse this precomputed string when encoding multiple metric samples (such as buckets, quantiles, and states), thus avoiding repeated work.

Performance and code improvements for label encoding:

* Added a new method `encode_common_labels_to_string` to precompute and cache common labels (constant and family labels) as a string, reducing repeated encoding work.
* Introduced `encode_label_set_with_common`, which takes the precomputed common labels and any additional labels, improving efficiency by avoiding repeated string construction.
* Updated the main `encode_label_set` method to use the new pre-encoding logic, simplifying its implementation and delegating to `encode_label_set_with_common`.
* Refactored metric encoding methods (`encode_buckets`, `encode_stateset`, and quantile encoding) to precompute common labels once and reuse them when encoding multiple samples, further improving performance. [[1]](diffhunk://#diff-51d2c234c48d9acf03c8e9a5eb96db6951681d87f7da81a82a636ce4c024b7abR272-R305) [[2]](diffhunk://#diff-51d2c234c48d9acf03c8e9a5eb96db6951681d87f7da81a82a636ce4c024b7abR432-R441) [[3]](diffhunk://#diff-51d2c234c48d9acf03c8e9a5eb96db6951681d87f7da81a82a636ce4c024b7abR507-R516)