### PR TITLE
feat(encoder): avoid encoding empty metric family

### DIFF
--- a/fastmetrics/src/format/prost.rs
+++ b/fastmetrics/src/format/prost.rs
@@ -127,6 +127,11 @@ impl From<MetricType> for openmetrics_data_model::MetricType {
 
 impl encoder::MetricFamilyEncoder for MetricFamilyEncoder<'_> {
     fn encode(&mut self, metadata: &Metadata, metric: &dyn EncodeMetric) -> fmt::Result {
+        if metric.is_empty() {
+            // skip empty metric family
+            return Ok(());
+        }
+
         let mut metric_family = openmetrics_data_model::MetricFamily {
             name: {
                 match self.namespace {

--- a/fastmetrics/src/format/protobuf.rs
+++ b/fastmetrics/src/format/protobuf.rs
@@ -129,6 +129,11 @@ impl From<MetricType> for openmetrics_data_model::MetricType {
 
 impl encoder::MetricFamilyEncoder for MetricFamilyEncoder<'_> {
     fn encode(&mut self, metadata: &Metadata, metric: &dyn EncodeMetric) -> fmt::Result {
+        if metric.is_empty() {
+            // skip empty metric family
+            return Ok(());
+        }
+
         let mut metric_family = openmetrics_data_model::MetricFamily {
             name: {
                 match self.namespace {

--- a/fastmetrics/src/format/text.rs
+++ b/fastmetrics/src/format/text.rs
@@ -162,6 +162,11 @@ where
     W: fmt::Write,
 {
     fn encode(&mut self, metadata: &Metadata, metric: &dyn EncodeMetric) -> fmt::Result {
+        if metric.is_empty() {
+            // skip empty metric family
+            return Ok(());
+        }
+
         let metric_name = metric_name(self.namespace, metadata.name(), metadata.unit());
 
         self.encode_type(metric_name.as_ref(), metadata.metric_type())?;


### PR DESCRIPTION
This pull request introduces a mechanism to skip encoding of empty metric families across all supported output formats. It adds an `is_empty` method to the `EncodeMetric` trait, updates all metric family encoders to use this method, and provides comprehensive tests to ensure correct behavior. The main goal is to avoid emitting metadata lines (like `# TYPE`, `# HELP`, and `# UNIT`) for metric families that contain no data points.

**Trait and implementation changes:**

* Added a default `is_empty` method to the `EncodeMetric` trait, allowing each metric type to specify what it means to be "empty". By default, metrics are considered not empty.
* Implemented `is_empty` for `Family` metrics, delegating to the underlying collection's emptiness.
* Updated the `EncodeMetric` trait object implementation to delegate `is_empty` calls.

**Encoder logic updates:**

* Updated the OpenMetrics Protobuf, OpenMetrics text, and plain text encoders to skip encoding metric families that are empty, using the new `is_empty` method. [[1]](diffhunk://#diff-6c1b209d297d60bb2d77a46c4fc9794c980e29876f5b9a8db4299e2f98cd4de5R130-R134) [[2]](diffhunk://#diff-27cb1acd71916deda001e3d1c3b8d9caab65a7724882588e0cfd0657d202c3f7R132-R136) [[3]](diffhunk://#diff-51d2c234c48d9acf03c8e9a5eb96db6951681d87f7da81a82a636ce4c024b7abR165-R169)

**Testing:**

* Added new tests to ensure that empty metric families are not encoded, and that non-empty families are encoded as expected.